### PR TITLE
enabling overriding Bootstrap's default CSS properties

### DIFF
--- a/app/components/SelectField/index.js
+++ b/app/components/SelectField/index.js
@@ -21,7 +21,7 @@ function SelectField(props) {
   }
   return (
     <div className={`form-group col-xs-${props.width}`}>
-      <Field className={styles.select} name={props.name} component="select" defaultValue="">
+      <Field className="form-control" name={props.name} component="select" defaultValue="">
         <option key="option-default" value="" disabled>{props.label}</option>
         {options}
       </Field>

--- a/app/components/StateSelect/index.js
+++ b/app/components/StateSelect/index.js
@@ -10,7 +10,7 @@ function StateSelect(props) {
   }
   return (
     <div className="form-group">
-      <select className={styles.stateSelect} onChange={props.onChange} defaultValue="">
+      <select className={`form-control ${styles.stateSelect}`} onChange={props.onChange} defaultValue="">
         <option key={"state-default"} value="" className={styles.default} disabled>Select your state</option>
         {options}
       </select>

--- a/app/components/StateSelect/styles.css
+++ b/app/components/StateSelect/styles.css
@@ -5,12 +5,6 @@
   font-weight: bold;
   font-size: 16px;
   height: 50px;
-  width: 100%;
-  display: block;
-  margin: 0 auto;
-}
-
-select.stateSelect {
   text-align: center;
   text-align-last: center;
 }

--- a/app/components/TextField/index.js
+++ b/app/components/TextField/index.js
@@ -15,7 +15,7 @@ import { Field } from 'redux-form';
 function TextField(props) {
   return (
     <div className={`form-group col-xs-${props.width}`}>
-      <Field type="text" name={props.name} placeholder={props.label} component="input" />
+      <Field type="text" className="form-control" name={props.name} placeholder={props.label} component="input" />
     </div>
   );
 }

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -10,7 +10,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 
 import Header from 'components/Header';
-// import styles from './styles.css';
+import styles from './styles.css';
 
 function App(props) {
   return (

--- a/app/containers/App/styles.css
+++ b/app/containers/App/styles.css
@@ -41,3 +41,7 @@ select {
 :-ms-input-placeholder {
   color: #000;
 }
+
+:global .form-control {
+  border-radius: 0px;
+}

--- a/app/containers/CheckRegPage/index.js
+++ b/app/containers/CheckRegPage/index.js
@@ -40,22 +40,28 @@ export class CheckRegPage extends React.Component { // eslint-disable-line react
     }
     return (
       <div>
-        <div className={styles.header}>
-          <FormattedMessage {...messages.header} />
-        </div>
-        <div className="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
-          <div className={styles.checkRegPage}>
-            <StateSelect states={this.props.states} onChange={this.props.onChangeState} />
-            {formBody}
-            <div className={styles.message}>
-              If you are not registered, then download your <a target="_blank" href="http://www.eac.gov/assets/1/Documents/Federal%20Voter%20Registration_1-25-16_ENG.pdf" className={styles.link}> registration form</a>!
-            </div>
-
+        <div className="row">
+          <div className={styles.header}>
+            <FormattedMessage {...messages.header} />
           </div>
-          <pre>{formResults}</pre>
+        </div>
+        <div className="row">
+          <div className="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-12">
+            <div>
+              <StateSelect states={this.props.states} onChange={this.props.onChangeState} />
+              {formBody}
+              <div className={styles.message}>
+                If you are not registered, then download your <a target="_blank" href="http://www.eac.gov/assets/1/Documents/Federal%20Voter%20Registration_1-25-16_ENG.pdf" className={styles.link}> registration form</a>!
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+            <pre>{formResults}</pre>
+          </div>
         </div>
         <img className={styles.flag} src={flag} role="presentation" />
-
       </div>
     );
   }

--- a/app/index.html
+++ b/app/index.html
@@ -9,12 +9,12 @@
     <link rel="manifest" href="manifest.json">
     <meta name="mobile-web-app-capable" content="yes">
     <title>React.js Boilerplate</title>
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
   </head>
   <body>
     <!-- The app hooks into this div -->
     <div id="app"></div>
-    <!-- Bootstrap -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <!-- A lot of magic happens in this file. HtmlWebpackPlugin automatically includes all assets (e.g. bundle.js, main.css) with the correct HTML tags, which is why they are missing in this HTML file. Don't add any assets here! (Check out webpackconfig.js if you want to know more) -->
   </body>
 </html>


### PR DESCRIPTION
To override globally, put ":global" in front of the CSS selector. Look at App/styles.css for an example.

To override locally, just add another class like you would normally. Look at StateSelect/index.js for an example.
