### PR TITLE
Extract app secrets into ignored config file, route email subscribe to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ ansible/staging
 
 # cli-real-favicon faviconData file
 app/faviconData.json
+
+# Config (with secrets)
+config.js

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Executive
 
 1. Clone this repo
 2. `npm install`
-3. `npm start`
+3. Copy `config-example.js` to `config.js` and fill with the appropriate values
+4. `npm start`
 
 The development server by default is at `localhost:3000`
 

--- a/app/components/EmailForm/index.js
+++ b/app/components/EmailForm/index.js
@@ -10,15 +10,12 @@ import { Field } from 'redux-form';
 import { reduxForm } from 'redux-form/immutable';
 
 function EmailForm(props) {
-  let form;
-  if (props.isSubmitted) {
-    form = (<div>Currently not working. Please try again later.</div>);
-  } else {
-    form = (<form onSubmit={props.submitEmail} className="form-inline">
+  const form = (
+    <form onSubmit={props.submitEmail} className="form-inline">
       <Field type="text" name="email" className={styles.input} placeholder="Email" component="input" required />
       <button type="submit" className={styles.submit}>Submit</button>
-    </form>);
-  }
+    </form>
+  );
 
   return (
     <div className={styles.email}>
@@ -26,13 +23,14 @@ function EmailForm(props) {
         Don't forget to vote! <span className={styles.wrap}>Sign up for reminders.</span>
       </div>
       {form}
+      <div>{props.status}</div>
     </div>
   );
 }
 
 EmailForm.propTypes = {
   submitEmail: React.PropTypes.func,
-  isSubmitted: React.PropTypes.bool,
+  status: React.PropTypes.string,
 };
 
 export default reduxForm({

--- a/app/config.js
+++ b/app/config.js
@@ -1,4 +1,0 @@
-export const API_BASE = 'https://api-staging.votemate.us';
-export const GOOGLE_MAPS_API = 'AIzaSyAMfwLqZ6TriYOFafbR6ty6cKFIjRyIB3w';
-export const MAILCHIMP_API = '06031ef9fda5590d5d5b41ab0602c827-us14';
-export const LIST_ID = 'ac676d276f';

--- a/app/containers/CheckRegPage/constants.js
+++ b/app/containers/CheckRegPage/constants.js
@@ -4,8 +4,6 @@
  *
  */
 
-import * as cfg from 'config';
-
 /* action constants */
 export const FETCH_STATES = 'app/CheckRegPage/FETCH_STATES';
 export const FETCH_INITIAL_STATE = 'app/CheckRegPage/FETCH_INITIAL_STATE';
@@ -18,7 +16,7 @@ export const LOAD_RESULTS = 'app/CheckRegPage/LOAD_RESULTS';
 export const SET_API_ERR_MSG = 'app/CheckRegpage/SET_API_ERR_MSG';
 
 /* API URLs */
-export const FETCH_STATES_URL = `${cfg.API_BASE}/check-registration-form/`;
+export const FETCH_STATES_URL = `${API_BASE}/check-registration-form/`; // eslint-disable-line no-undef
 export const FETCH_STATE_URL = (state) => `${FETCH_STATES_URL}${state}/`;
-export const FETCH_LOCATION_URL = `https://www.googleapis.com/geolocation/v1/geolocate?key=${cfg.GOOGLE_MAPS_API}`;
-export const FETCH_ADDRESS_URL = (lat, lng) => `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${cfg.GOOGLE_MAPS_API}`;
+export const FETCH_LOCATION_URL = `https://www.googleapis.com/geolocation/v1/geolocate?key=${GOOGLE_MAPS_API_KEY}`; // eslint-disable-line no-undef
+export const FETCH_ADDRESS_URL = (lat, lng) => `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${GOOGLE_MAPS_API_KEY}`; // eslint-disable-line no-undef

--- a/app/containers/PostRegPage/actions.js
+++ b/app/containers/PostRegPage/actions.js
@@ -6,3 +6,10 @@ export function submitEmail(params) {
     params,
   };
 }
+
+export function updateEmailStatus(status) {
+  return {
+    type: c.UPDATE_EMAIL_STATUS,
+    status,
+  };
+}

--- a/app/containers/PostRegPage/constants.js
+++ b/app/containers/PostRegPage/constants.js
@@ -4,7 +4,6 @@
  *
  */
 
-import * as cfg from 'config';
-
 export const SUBMIT_EMAIL = 'app/CheckRegPage/SUBMIT_EMAIL';
-export const FETCH_MAILCHIMP_URL = `https://us14.api.mailchimp.com/2.0/lists/subscribe.json?apikey=${cfg.MAILCHIMP_API}&id=${cfg.LIST_ID}&double_optin=false&email[email]=`;
+export const UPDATE_EMAIL_STATUS = 'app/CheckRegPage/UPDATE_EMAIL_STATUS';
+export const SUBSCRIBE_EMAIL_URL = `${API_BASE}/emails/subscribe/`; // eslint-disable-line no-undef

--- a/app/containers/PostRegPage/index.js
+++ b/app/containers/PostRegPage/index.js
@@ -29,7 +29,7 @@ export class PostRegPage extends React.Component { // eslint-disable-line react/
       <div className={styles.postRegPage}>
         <PostRegForm registered={registered} state={this.props.params.state} />
         <div className={styles.social}>
-          <EmailForm submitEmail={this.props.onSubmitEmail} state={this.props.params.state} isSubmitted={this.props.isSubmitted} />
+          <EmailForm submitEmail={this.props.onSubmitEmail} state={this.props.params.state} status={this.props.emailStatus} />
           <SocialButtons />
         </div>
       </div>
@@ -41,7 +41,7 @@ PostRegPage.propTypes = {
   params: React.PropTypes.object,
   onSubmitEmail: React.PropTypes.func,
   dispatch: React.PropTypes.func,
-  isSubmitted: React.PropTypes.bool,
+  emailStatus: React.PropTypes.string,
 };
 
 function mapDispatchToProps(dispatch, ownProps) {
@@ -55,7 +55,7 @@ function mapDispatchToProps(dispatch, ownProps) {
 }
 
 const mapStateToProps = createStructuredSelector({
-  isSubmitted: selectors.selectSubmitted(),
+  emailStatus: selectors.selectEmailStatus(),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PostRegPage);

--- a/app/containers/PostRegPage/reducer.js
+++ b/app/containers/PostRegPage/reducer.js
@@ -17,6 +17,9 @@ function postRegPageReducer(state = initialState, action) {
       return state
         .set('params', action.params)
         .set('isSubmitted', true);
+    case c.UPDATE_EMAIL_STATUS:
+      return state
+        .set('emailStatus', action.status);
     default:
       return state;
   }

--- a/app/containers/PostRegPage/selectors.js
+++ b/app/containers/PostRegPage/selectors.js
@@ -2,9 +2,9 @@ import { createSelector } from 'reselect';
 
 const selectPostRegPageDomain = () => (state) => state.get('PostRegPage');
 
-const selectSubmitted = () => createSelector(
+const selectEmailStatus = () => createSelector(
   selectPostRegPageDomain(),
-  (postRegDomain) => postRegDomain.get('isSubmitted')
+  (postRegDomain) => postRegDomain.get('emailStatus')
 );
 
 const selectState = () => createSelector(
@@ -25,7 +25,7 @@ const selectEmail = () => createSelector(
 );
 
 export {
-  selectSubmitted,
+  selectEmailStatus,
   selectState,
   selectRegistered,
   selectEmail,

--- a/config-example.js
+++ b/config-example.js
@@ -1,0 +1,14 @@
+module.exports = {
+  development: {
+    API_BASE: JSON.stringify('https://api-staging.votemate.us'),
+    GOOGLE_MAPS_API_KEY: JSON.stringify('AIzaSyCMCxPvABPSovm-bhezhEczBPQcZ3OtOVs'),
+  },
+  production: {
+    API_BASE: JSON.stringify('https://api.votemate.us'),
+    GOOGLE_MAPS_API_KEY: JSON.stringify('AIzaSyDpCoMETST3psVqsBTqiDtNYqgYVX6Pq54'),
+  },
+  test: {
+    API_BASE: JSON.stringify('https://api-staging.votemate.us'),
+    GOOGLE_MAPS_API_KEY: JSON.stringify('AIzaSyCMCxPvABPSovm-bhezhEczBPQcZ3OtOVs'),
+  },
+};

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -2,6 +2,8 @@
  * COMMON WEBPACK CONFIGURATION
  */
 
+const CONFIG = require('../../config.js');
+
 const path = require('path');
 const webpack = require('webpack');
 
@@ -60,11 +62,13 @@ module.exports = (options) => ({
     // Always expose NODE_ENV to webpack, in order to use `process.env.NODE_ENV`
     // inside your code for any environment checks; UglifyJS will automatically
     // drop any unreachable code.
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-      },
-    }),
+    new webpack.DefinePlugin(
+      Object.assign({
+        'process.env': {
+          NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+        },
+      }, CONFIG[process.env.NODE_ENV])
+    ),
   ]),
   postcss: () => options.postcssPlugins,
   resolve: {


### PR DESCRIPTION
This PR moves all per-environment configuration and app secrets to a gitignored file called `config.js`. This lets us point the app at different api servers depending on environment and use different API keys for each environment. In addition, this moves mailchimp authentication to the API so that the mailchimp API key will never reach the client side. Only a subscribe endpoint is exposed. 
